### PR TITLE
Slash Commands

### DIFF
--- a/EMI.iml
+++ b/EMI.iml
@@ -1,6 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8">
+  <component name="FacetManager">
+    <facet type="minecraft" name="Minecraft">
+      <configuration>
+        <autoDetectTypes>
+          <platformType>SPIGOT</platformType>
+        </autoDetectTypes>
+      </configuration>
+    </facet>
+  </component>
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_16">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
@@ -16,11 +25,11 @@
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.code.gson:gson:2.8.0" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: net.md-5:bungeecord-chat:1.16-R0.4" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.yaml:snakeyaml:1.28" level="project" />
-    <orderEntry type="library" name="Maven: co.aikar:acf-bukkit:0.5.0-SNAPSHOT" level="project" />
+    <orderEntry type="library" name="Maven: co.aikar:acf-paper:0.5.1-SNAPSHOT" level="project" />
     <orderEntry type="library" name="Maven: co.aikar:idb-core:1.0.0-SNAPSHOT" level="project" />
-    <orderEntry type="library" name="Maven: com.zaxxer:HikariCP:2.4.1" level="project" />
-    <orderEntry type="library" name="Maven: org.slf4j:slf4j-api:1.7.12" level="project" />
-    <orderEntry type="library" name="Maven: net.dv8tion:JDA:4.3.0_277" level="project" />
+    <orderEntry type="library" name="Maven: com.zaxxer:HikariCP:5.0.0" level="project" />
+    <orderEntry type="library" name="Maven: org.slf4j:slf4j-api:2.0.0-alpha1" level="project" />
+    <orderEntry type="library" name="Maven: net.dv8tion:JDA:4.4.0_350" level="project" />
     <orderEntry type="library" name="Maven: com.google.code.findbugs:jsr305:3.0.2" level="project" />
     <orderEntry type="library" name="Maven: org.jetbrains:annotations:16.0.1" level="project" />
     <orderEntry type="library" name="Maven: com.neovisionaries:nv-websocket-client:2.14" level="project" />
@@ -31,17 +40,17 @@
     <orderEntry type="library" scope="RUNTIME" name="Maven: com.fasterxml.jackson.core:jackson-databind:2.10.1" level="project" />
     <orderEntry type="library" scope="RUNTIME" name="Maven: com.fasterxml.jackson.core:jackson-annotations:2.10.1" level="project" />
     <orderEntry type="library" scope="RUNTIME" name="Maven: com.fasterxml.jackson.core:jackson-core:2.10.1" level="project" />
-    <orderEntry type="library" name="Maven: com.jagrosh:jda-utilities-command:3.0.5" level="project" />
-    <orderEntry type="library" name="Maven: org.json:json:20160810" level="project" />
-    <orderEntry type="library" name="Maven: com.jagrosh:jda-utilities-commons:3.0.5" level="project" />
-    <orderEntry type="library" name="Maven: com.jagrosh:jda-utilities-doc:3.0.5" level="project" />
-    <orderEntry type="library" name="Maven: com.jagrosh:jda-utilities-examples:3.0.5" level="project" />
-    <orderEntry type="library" name="Maven: com.jagrosh:jda-utilities-menu:3.0.5" level="project" />
-    <orderEntry type="library" name="Maven: com.jagrosh:jda-utilities-oauth2:3.0.5" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.projectlombok:lombok:1.18.4" level="project" />
+    <orderEntry type="library" name="Maven: pw.chew:jda-chewtils-command:1.23.0" level="project" />
+    <orderEntry type="library" name="Maven: pw.chew:jda-chewtils-commons:1.23.0" level="project" />
+    <orderEntry type="library" name="Maven: pw.chew:jda-chewtils-doc:1.23.0" level="project" />
+    <orderEntry type="library" name="Maven: pw.chew:jda-chewtils-examples:1.23.0" level="project" />
+    <orderEntry type="library" name="Maven: pw.chew:jda-chewtils-menu:1.23.0" level="project" />
+    <orderEntry type="library" name="Maven: pw.chew:jda-chewtils-oauth2:1.23.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.projectlombok:lombok:1.18.22" level="project" />
     <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpclient:4.5.13" level="project" />
     <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpcore:4.4.13" level="project" />
     <orderEntry type="library" name="Maven: commons-logging:commons-logging:1.2" level="project" />
     <orderEntry type="library" name="Maven: commons-codec:commons-codec:1.11" level="project" />
+    <orderEntry type="library" name="Maven: org.json:json:20211205" level="project" />
   </component>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.everneth</groupId>
     <artifactId>EMI</artifactId>
-    <version>1.5.2</version>
+    <version>1.6.0</version>
 
     <repositories>
         <repository>
@@ -32,7 +32,26 @@
             <name>bintray</name>
             <url>https://jcenter.bintray.com</url>
         </repository>
+        <repository>
+            <id>chew-m2</id>
+            <name>m2-chew</name>
+            <url>https://m2.chew.pro/releases</url>
+        </repository>
     </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <releases>
+                <updatePolicy>never</updatePolicy>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <id>central</id>
+            <name>Maven Plugin Repository</name>
+            <url>http://repo1.maven.org/maven2</url>
+        </pluginRepository>
+    </pluginRepositories>
 
     <dependencies>
         <!--Spigot API-->
@@ -45,8 +64,8 @@
         <!--ACF-->
         <dependency>
             <groupId>co.aikar</groupId>
-            <artifactId>acf-bukkit</artifactId>
-            <version>0.5.0-SNAPSHOT</version>
+            <artifactId>acf-paper</artifactId>
+            <version>0.5.1-SNAPSHOT</version>
         </dependency>
         <!--IDB-->
         <dependency>
@@ -58,13 +77,13 @@
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
-            <version>2.4.1</version>
+            <version>5.0.0</version>
         </dependency>
         <!--JDA-->
         <dependency>
             <groupId>net.dv8tion</groupId>
             <artifactId>JDA</artifactId>
-            <version>4.3.0_277</version>
+            <version>4.4.0_350</version>
             <exclusions>
                 <exclusion>
                     <groupId>club.minnced</groupId>
@@ -72,11 +91,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!--JDA-Utilities-->
+        <!--JDA-Chewtils-->
         <dependency>
-            <groupId>com.jagrosh</groupId>
-            <artifactId>jda-utilities</artifactId>
-            <version>3.0.5</version>
+            <groupId>pw.chew</groupId>
+            <artifactId>jda-chewtils</artifactId>
+            <version>1.23.0</version>
             <scope>compile</scope>
             <type>pom</type>
         </dependency>
@@ -84,7 +103,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.4</version>
+            <version>1.18.22</version>
             <scope>provided</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient -->
@@ -93,6 +112,12 @@
             <artifactId>httpclient</artifactId>
             <version>4.5.13</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.json/json -->
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20211205</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -100,10 +125,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
+                <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>16</source>
+                    <target>16</target>
                     <compilerArgs>
                         <arg>-parameters</arg>
                     </compilerArgs>
@@ -112,7 +137,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.3.1-SNAPSHOT</version>
                 <configuration>
                     <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
                     <relocations>

--- a/src/main/java/com/everneth/emi/EMI.java
+++ b/src/main/java/com/everneth/emi/EMI.java
@@ -126,6 +126,7 @@ public class EMI extends JavaPlugin {
         commandManager.registerCommand(new InfoCommand());
     }
 
+    // While the bot is offline we want to unregister all commands inside the guild
     private void unregisterCommands()
     {
         Guild guild = EMI.getJda().getGuildById(plugin.getConfig().getLong("guild-id"));

--- a/src/main/java/com/everneth/emi/EMI.java
+++ b/src/main/java/com/everneth/emi/EMI.java
@@ -139,12 +139,12 @@ public class EMI extends JavaPlugin {
     {
         CommandClientBuilder builder = new CommandClientBuilder();
         // force the builder to create guild commands to avoid long global registration times
-        builder.forceGuildOnly(this.getConfig().getLong("guild-id"));
+        builder.forceGuildOnly(getConfig().getLong("guild-id"));
 
         // the need for a prefix has been deprecated with slash commands
         //builder.setPrefix(this.getConfig().getString("bot-prefix"));
 
-        builder.setActivity(Activity.listening(this.getConfig().getString("bot-game")));
+        builder.setActivity(Activity.watching(getConfig().getString("bot-game")));
         builder.addSlashCommands(new HelpClearCommand(),
                 new ConfirmSyncCommand(),
                 new DenySyncCommand(),
@@ -174,7 +174,7 @@ public class EMI extends JavaPlugin {
             guild.loadMembers();
 
             // cache the help channel history so message history persists through a reset
-            guild.getTextChannelById(plugin.getConfig().getLong("help-channel-id")).getHistoryFromBeginning(100).complete();
+            guild.getTextChannelById(plugin.getConfig().getLong("help-channel-id")).getHistoryFromBeginning(100);
         }
         catch(Exception e)
         {

--- a/src/main/java/com/everneth/emi/EMI.java
+++ b/src/main/java/com/everneth/emi/EMI.java
@@ -19,6 +19,7 @@ import com.everneth.emi.managers.MotdManager;
 import com.everneth.emi.managers.ReportManager;
 import com.everneth.emi.models.*;
 import com.everneth.emi.models.mint.*;
+import com.everneth.emi.services.WhitelistService;
 import com.everneth.emi.utils.PlayerUtils;
 
 import com.jagrosh.jdautilities.command.CommandClient;
@@ -89,6 +90,10 @@ public class EMI extends JavaPlugin {
 
         // remove all the registered slash commands from the guild
         unregisterCommands();
+
+        // In the event someone requested temporary whitelisting less than 5 minutes before a server shutdown,
+        // we want to remove them so that they're not permanently on the whitelist
+        WhitelistService.getService().removeAllFromWhitelist();
         jda.shutdown();
 
         MintProjectManager manager = MintProjectManager.getMintProjectManager();

--- a/src/main/java/com/everneth/emi/EMI.java
+++ b/src/main/java/com/everneth/emi/EMI.java
@@ -144,7 +144,6 @@ public class EMI extends JavaPlugin {
         // the need for a prefix has been deprecated with slash commands
         //builder.setPrefix(this.getConfig().getString("bot-prefix"));
 
-        builder.setActivity(Activity.watching(getConfig().getString("bot-game")));
         builder.addSlashCommands(new HelpClearCommand(),
                 new CloseReportCommand(),
                 new ApplyCommand(),
@@ -155,10 +154,13 @@ public class EMI extends JavaPlugin {
 
         // register our global commands separately
         CommandClientBuilder globalBuilder = new CommandClientBuilder();
+        globalBuilder.setActivity(Activity.watching(getConfig().getString("bot-game")));
+        
         globalBuilder.addSlashCommands(new ConfirmSyncCommand(), new DenySyncCommand());
+        globalBuilder.setOwnerId(this.getConfig().getString("bot-owner-id"));
 
-        CommandClient globalClient = globalBuilder.build();
         CommandClient client = builder.build();
+        CommandClient globalClient = globalBuilder.build();
 
         try {
             jda = JDABuilder.createDefault(config.getString("bot-token"))

--- a/src/main/java/com/everneth/emi/EMI.java
+++ b/src/main/java/com/everneth/emi/EMI.java
@@ -90,11 +90,11 @@ public class EMI extends JavaPlugin {
 
         // remove all the registered slash commands from the guild
         unregisterCommands();
-
+        jda.shutdown();
+        
         // In the event someone requested temporary whitelisting less than 5 minutes before a server shutdown,
         // we want to remove them so that they're not permanently on the whitelist
         WhitelistService.getService().removeAllFromWhitelist();
-        jda.shutdown();
 
         MintProjectManager manager = MintProjectManager.getMintProjectManager();
         for(MintProject project : manager.getProjects().values())

--- a/src/main/java/com/everneth/emi/EMI.java
+++ b/src/main/java/com/everneth/emi/EMI.java
@@ -155,7 +155,7 @@ public class EMI extends JavaPlugin {
         // register our global commands separately
         CommandClientBuilder globalBuilder = new CommandClientBuilder();
         globalBuilder.setActivity(Activity.watching(getConfig().getString("bot-game")));
-        
+
         globalBuilder.addSlashCommands(new ConfirmSyncCommand(), new DenySyncCommand());
         globalBuilder.setOwnerId(this.getConfig().getString("bot-owner-id"));
 

--- a/src/main/java/com/everneth/emi/EMI.java
+++ b/src/main/java/com/everneth/emi/EMI.java
@@ -91,7 +91,7 @@ public class EMI extends JavaPlugin {
         // remove all the registered slash commands from the guild
         unregisterCommands();
         jda.shutdown();
-        
+
         // In the event someone requested temporary whitelisting less than 5 minutes before a server shutdown,
         // we want to remove them so that they're not permanently on the whitelist
         WhitelistService.getService().removeAllFromWhitelist();

--- a/src/main/java/com/everneth/emi/EMI.java
+++ b/src/main/java/com/everneth/emi/EMI.java
@@ -146,8 +146,6 @@ public class EMI extends JavaPlugin {
 
         builder.setActivity(Activity.watching(getConfig().getString("bot-game")));
         builder.addSlashCommands(new HelpClearCommand(),
-                new ConfirmSyncCommand(),
-                new DenySyncCommand(),
                 new CloseReportCommand(),
                 new ApplyCommand(),
                 new WhitelistAppCommand(),
@@ -155,11 +153,16 @@ public class EMI extends JavaPlugin {
                 new UnsyncCommand());
         builder.setOwnerId(this.getConfig().getString("bot-owner-id"));
 
+        // register our global commands separately
+        CommandClientBuilder globalBuilder = new CommandClientBuilder();
+        globalBuilder.addSlashCommands(new ConfirmSyncCommand(), new DenySyncCommand());
+
+        CommandClient globalClient = globalBuilder.build();
         CommandClient client = builder.build();
 
         try {
             jda = JDABuilder.createDefault(config.getString("bot-token"))
-                    .addEventListeners(client,
+                    .addEventListeners(client, globalClient,
                             new MessageReceivedListener(),
                             new ReactionListener(),
                             new RoleChangeListener(),

--- a/src/main/java/com/everneth/emi/commands/DiscordSyncCommands.java
+++ b/src/main/java/com/everneth/emi/commands/DiscordSyncCommands.java
@@ -72,8 +72,8 @@ public class DiscordSyncCommands extends BaseCommand {
                 dsm.addSyncRequest(player, user);
                 user.openPrivateChannel().queue(privateChannel ->
                         privateChannel.sendMessage(player.getName() + " is attempting to link their minecraft account with our Discord guild. " +
-                                "If this is you, please use !confirmsync to complete the account synchronization. " +
-                                "If this is not done by you, please use !denysync forward this message to staff immediately. Thank you!").queue());
+                                "If this is you, please use `/confirmsync` to complete the account synchronization. " +
+                                "If this is not done by you, please use `/denysync` forward this message to staff immediately. Thank you!").queue());
 
                 player.sendMessage("Please check your Discord DMs to verify your account. " +
                         "If you did not receive a message, check that your privacy settings " +

--- a/src/main/java/com/everneth/emi/commands/DiscordSyncCommands.java
+++ b/src/main/java/com/everneth/emi/commands/DiscordSyncCommands.java
@@ -70,14 +70,20 @@ public class DiscordSyncCommands extends BaseCommand {
             User user = member.getUser();
             if (user.getName().equalsIgnoreCase(name) && user.getDiscriminator().equals(discriminator)) {
                 dsm.addSyncRequest(player, user);
-                user.openPrivateChannel().queue(privateChannel ->
-                        privateChannel.sendMessage(player.getName() + " is attempting to link their minecraft account with our Discord guild. " +
-                                "If this is you, please use `/confirmsync` to complete the account synchronization. " +
-                                "If this is not done by you, please use `/denysync` forward this message to staff immediately. Thank you!").queue());
-
-                player.sendMessage("Please check your Discord DMs to verify your account. " +
-                        "If you did not receive a message, check that your privacy settings " +
-                        "allow messages from Everneth Discord members and try again.");
+                try {
+                    user.openPrivateChannel().queue(privateChannel ->
+                            privateChannel.sendMessage(player.getName() + " is attempting to link their minecraft account with our Discord guild. " +
+                                    "If this is you, please use `/confirmsync` to complete the account synchronization. " +
+                                    "If this is not done by you, please use `/denysync` forward this message to staff immediately. Thank you!").queue());
+                }
+                catch (Exception e)
+                {
+                    EMI.getPlugin().getLogger().warning(e.getMessage());
+                    dsm.removeSyncRequest(player);
+                    player.sendMessage(Utils.color("&cFailed to create a sync request because I cannot message you on Discord. " +
+                            "Please enable messages from Everneth Discord members and try again."));
+                }
+                player.sendMessage(Utils.color("&aMessage sent. Please check your discord DMs to confirm your synchronization!"));
                 return;
             }
         }

--- a/src/main/java/com/everneth/emi/commands/DiscordSyncCommands.java
+++ b/src/main/java/com/everneth/emi/commands/DiscordSyncCommands.java
@@ -13,6 +13,8 @@ import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.exceptions.ErrorHandler;
+import net.dv8tion.jda.api.requests.ErrorResponse;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
@@ -69,22 +71,19 @@ public class DiscordSyncCommands extends BaseCommand {
             // If we find a user matching the name and discriminator, proceed with sync request
             User user = member.getUser();
             if (user.getName().equalsIgnoreCase(name) && user.getDiscriminator().equals(discriminator)) {
-                dsm.addSyncRequest(player, user);
-                try {
-                    user.openPrivateChannel().queue(privateChannel ->
-                            privateChannel.sendMessage(player.getName() + " is attempting to link their minecraft account with our Discord guild. " +
-                                    "If this is you, please use `/confirmsync` to complete the account synchronization. " +
-                                    "If this is not done by you, please use `/denysync` and forward this message to staff immediately. Thank you!").queue());
-                }
-                catch (Exception e)
-                {
-                    EMI.getPlugin().getLogger().warning(e.getMessage());
-                    dsm.removeSyncRequest(player);
-                    player.sendMessage(Utils.color("&cFailed to create a sync request because I cannot message you on Discord. " +
-                            "Please enable messages from Everneth Discord members and try again."));
-                }
-                player.sendMessage(Utils.color("&aMessage sent. Please check your discord DMs to confirm your synchronization!"));
-                return;
+                user.openPrivateChannel()
+                        .flatMap(privateChannel -> privateChannel.sendMessage(player.getName() + " is attempting to link their minecraft account with our Discord guild. " +
+                                "If this is you, please use `/confirmsync` to complete the account synchronization. " +
+                                "If this is not done by you, please use `/denysync` and forward this message to staff immediately. Thank you!"))
+                        .queue(message -> {
+                            dsm.addSyncRequest(player, user);
+                            player.sendMessage(Utils.color("&aMessage sent. Please check your discord DMs to confirm your synchronization!"));
+                            return;
+                        }, new ErrorHandler()
+                                .handle(ErrorResponse.CANNOT_SEND_TO_USER, (error) -> {
+                                    player.sendMessage(Utils.color("&cRequest failed. Please enable direct messages from server members"));
+                                    return;
+                                }));
             }
         }
         player.sendMessage(Utils.color("&cUser not found! Please check your details and try again. If this is your third attempt, please contact Staff."));
@@ -101,14 +100,19 @@ public class DiscordSyncCommands extends BaseCommand {
         }
         Guild guild = EMI.getJda().getGuildById(plugin.getConfig().getLong("guild-id"));
         Member member = guild.getMemberById(discordId);
-        member.getUser().openPrivateChannel().queue(privateChannel ->
-                privateChannel.sendMessage("Your discord account has been unsynced with your minecraft account. If you did not request an unsync " +
-                            "please contact staff immediately.").queue());
+
+        member.getUser().openPrivateChannel()
+                .flatMap(privateChannel -> privateChannel.sendMessage("Your discord account has been unsynced with your minecraft account. " +
+                        "If you did not request an unsync please contact staff immediately."))
+                .queue(null, new ErrorHandler()
+                        .handle(ErrorResponse.CANNOT_SEND_TO_USER, (error) ->
+                            player.sendMessage(Utils.color("&cI tried to message you on discord and could not. " +
+                                    "Please enable direct messages from Everneth server members for future purposes."))));
 
         Role syncRole = guild.getRoleById(EMI.getPlugin().getConfig().getLong("synced-role-id"));
         guild.removeRoleFromMember(member, syncRole).queue();
 
-        DB.executeUpdateAsync("UPDATE players SET discord_id = 0 WHERE ? IN (player_uuid,alt_uuid)", player.getUniqueId().toString());
+        DB.executeUpdateAsync("UPDATE players SET discord_id = NULL WHERE ? IN (player_uuid,alt_uuid)", player.getUniqueId().toString());
         player.sendMessage(Utils.color("Your discord account has been successfully unsynced. Please use &a/discord sync &fto set up with a new account."));
     }
 }

--- a/src/main/java/com/everneth/emi/commands/DiscordSyncCommands.java
+++ b/src/main/java/com/everneth/emi/commands/DiscordSyncCommands.java
@@ -81,7 +81,6 @@ public class DiscordSyncCommands extends BaseCommand {
                         }, new ErrorHandler()
                                 .handle(ErrorResponse.CANNOT_SEND_TO_USER, (error) -> {
                                     player.sendMessage(Utils.color("&cRequest failed. Please enable direct messages from server members"));
-                                    return;
                                 }));
                 return;
             }

--- a/src/main/java/com/everneth/emi/commands/DiscordSyncCommands.java
+++ b/src/main/java/com/everneth/emi/commands/DiscordSyncCommands.java
@@ -78,12 +78,12 @@ public class DiscordSyncCommands extends BaseCommand {
                         .queue(message -> {
                             dsm.addSyncRequest(player, user);
                             player.sendMessage(Utils.color("&aMessage sent. Please check your discord DMs to confirm your synchronization!"));
-                            return;
                         }, new ErrorHandler()
                                 .handle(ErrorResponse.CANNOT_SEND_TO_USER, (error) -> {
                                     player.sendMessage(Utils.color("&cRequest failed. Please enable direct messages from server members"));
                                     return;
                                 }));
+                return;
             }
         }
         player.sendMessage(Utils.color("&cUser not found! Please check your details and try again. If this is your third attempt, please contact Staff."));

--- a/src/main/java/com/everneth/emi/commands/DiscordSyncCommands.java
+++ b/src/main/java/com/everneth/emi/commands/DiscordSyncCommands.java
@@ -74,7 +74,7 @@ public class DiscordSyncCommands extends BaseCommand {
                     user.openPrivateChannel().queue(privateChannel ->
                             privateChannel.sendMessage(player.getName() + " is attempting to link their minecraft account with our Discord guild. " +
                                     "If this is you, please use `/confirmsync` to complete the account synchronization. " +
-                                    "If this is not done by you, please use `/denysync` forward this message to staff immediately. Thank you!").queue());
+                                    "If this is not done by you, please use `/denysync` and forward this message to staff immediately. Thank you!").queue());
                 }
                 catch (Exception e)
                 {

--- a/src/main/java/com/everneth/emi/commands/SupportCommand.java
+++ b/src/main/java/com/everneth/emi/commands/SupportCommand.java
@@ -54,7 +54,7 @@ public class SupportCommand extends BaseCommand {
         eb.setFooter("Help requested!", null);
 
         // Make the bot post the embed to the channel and notify the player
-        EMI.getJda().getTextChannelById(EMI.getPlugin().getConfig().getLong("help-channel-id")).sendMessage(eb.build()).queue();
+        EMI.getJda().getTextChannelById(EMI.getPlugin().getConfig().getLong("help-channel-id")).sendMessageEmbeds(eb.build()).queue();
         player.sendMessage(Utils.color("<&6The Wench&f> Your report submitted to &6#help&f! A staff member " +
                 "will get back to you shortly. <3"));
     }

--- a/src/main/java/com/everneth/emi/commands/bot/ApplyCommand.java
+++ b/src/main/java/com/everneth/emi/commands/bot/ApplyCommand.java
@@ -3,24 +3,26 @@ package com.everneth.emi.commands.bot;
 import com.everneth.emi.EMI;
 import com.everneth.emi.models.WhitelistApp;
 import com.everneth.emi.services.WhitelistAppService;
-import com.jagrosh.jdautilities.command.Command;
-import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.command.SlashCommand;
 import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 
-public class ApplyCommand extends Command {
+public class ApplyCommand extends SlashCommand {
     public ApplyCommand()
     {
         this.name = "apply";
+        this.help = "Fill out an application to request whitelisting.";
+
         this.guildOnly = false;
     }
     @Override
-    public void execute(CommandEvent event)
+    public void execute(SlashCommandEvent event)
     {
         long applicationRoleId = EMI.getPlugin().getConfig().getLong("applicant-role-id");
         Role applicantRole = event.getGuild().getRoleById(applicationRoleId);
 
-        if(WhitelistAppService.getService().findByDiscordId(event.getAuthor().getIdLong()) == null) {
-            WhitelistAppService.getService().addApp(event.getAuthor().getIdLong(), new WhitelistApp());
+        if(WhitelistAppService.getService().findByDiscordId(event.getUser().getIdLong()) == null) {
+            WhitelistAppService.getService().addApp(event.getUser().getIdLong(), new WhitelistApp());
         }
     }
 }

--- a/src/main/java/com/everneth/emi/commands/bot/ApplyCommand.java
+++ b/src/main/java/com/everneth/emi/commands/bot/ApplyCommand.java
@@ -12,6 +12,9 @@ public class ApplyCommand extends SlashCommand {
     {
         this.name = "apply";
         this.help = "Fill out an application to request whitelisting.";
+
+        this.defaultEnabled = false;
+        this.disabledRoles = new String[]{EMI.getPlugin().getConfig().getString("member-role-id")};
     }
     @Override
     public void execute(SlashCommandEvent event)

--- a/src/main/java/com/everneth/emi/commands/bot/ApplyCommand.java
+++ b/src/main/java/com/everneth/emi/commands/bot/ApplyCommand.java
@@ -12,8 +12,6 @@ public class ApplyCommand extends SlashCommand {
     {
         this.name = "apply";
         this.help = "Fill out an application to request whitelisting.";
-
-        this.guildOnly = false;
     }
     @Override
     public void execute(SlashCommandEvent event)

--- a/src/main/java/com/everneth/emi/commands/bot/CloseReportCommand.java
+++ b/src/main/java/com/everneth/emi/commands/bot/CloseReportCommand.java
@@ -6,23 +6,25 @@ import com.everneth.emi.models.EMIPlayer;
 import com.everneth.emi.utils.FileUtils;
 
 import com.everneth.emi.utils.PlayerUtils;
-import com.jagrosh.jdautilities.command.Command;
-import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.command.SlashCommand;
 import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.*;
 
-public class CloseReportCommand extends Command {
+public class CloseReportCommand extends SlashCommand {
+
     public CloseReportCommand() {
         this.name = "close-report";
+        this.help = "Close an open report from a user";
     }
 
     @Override
-    protected void execute(CommandEvent event) {
+    protected void execute(SlashCommandEvent event) {
 
         long mintRoleId = EMI.getPlugin().getConfig().getLong("mint-role-id");
         long staffRoleId = EMI.getPlugin().getConfig().getLong("staff-role-id");
@@ -64,7 +66,7 @@ public class CloseReportCommand extends Command {
             } else {
                 // You can;t even use this at all, we're not checking any further
                 // TODO: Mute member if attempts are made to use command to spam replies
-                event.reply("Sorry dear, you must be a member of staff to use this command. :heart: ");
+                event.reply("Sorry dear, you must be a member of staff to use this command. :heart: ").setEphemeral(true).queue();
             }
         }
         else if(event.getChannel().getName().contains("_mint"))
@@ -97,7 +99,7 @@ public class CloseReportCommand extends Command {
             } else {
                 // You can;t even use this at all, we're not checking any further
                 // TODO: Mute member if attempts are made to use command to spam replies
-                event.reply("Sorry dear, you must be a member of MINT or Staff to use this command. :heart: ");
+                event.reply("Sorry dear, you must be a member of MINT or Staff to use this command. :heart: ").setEphemeral(true).queue();
             }
         }
 

--- a/src/main/java/com/everneth/emi/commands/bot/CloseReportCommand.java
+++ b/src/main/java/com/everneth/emi/commands/bot/CloseReportCommand.java
@@ -21,6 +21,9 @@ public class CloseReportCommand extends SlashCommand {
     public CloseReportCommand() {
         this.name = "close-report";
         this.help = "Close an open report from a user";
+
+        this.defaultEnabled = false;
+        this.enabledRoles = new String[]{EMI.getPlugin().getConfig().getString("staff-role-id")};
     }
 
     @Override

--- a/src/main/java/com/everneth/emi/commands/bot/ConfirmSyncCommand.java
+++ b/src/main/java/com/everneth/emi/commands/bot/ConfirmSyncCommand.java
@@ -42,14 +42,14 @@ public class ConfirmSyncCommand extends SlashCommand {
             event.reply("No sync request exists for your account or it has already been synced.").setEphemeral(true).queue();
             return;
         }
+        else if (PlayerUtils.syncExists(toFind)) {
+            event.reply("You have already synced this account. If this is in error, please contact staff.").setEphemeral(true).queue();
+            return;
+        }
 
         int playerId = dsm.syncAccount(toFind);
         if (playerId == 0) {
             event.reply("Could not sync account, no player record found.").setEphemeral(true).queue();
-            return;
-        }
-        else if (PlayerUtils.syncExists(toFind)) {
-            event.reply("You have already synced this account. If this is in error, please contact staff.").setEphemeral(true).queue();
             return;
         }
 

--- a/src/main/java/com/everneth/emi/commands/bot/ConfirmSyncCommand.java
+++ b/src/main/java/com/everneth/emi/commands/bot/ConfirmSyncCommand.java
@@ -28,6 +28,8 @@ public class ConfirmSyncCommand extends SlashCommand {
     {
         this.name = "confirmsync";
         this.help = "Confirm an account synchronization from a minecraft account";
+
+        this.guildOnly = false;
     }
 
     @Override
@@ -36,17 +38,18 @@ public class ConfirmSyncCommand extends SlashCommand {
         DiscordSyncManager dsm = DiscordSyncManager.getDSM();
         User toFind = dsm.findSyncRequest(event.getUser());
 
-        int playerId = dsm.syncAccount(toFind);
         if (toFind == null) {
             event.reply("No sync request exists for your account or it has already been synced.").setEphemeral(true).queue();
             return;
         }
-        else if (PlayerUtils.syncExists(toFind)) {
-            event.reply("You have already synced this account. If this is in error, please contact staff.").setEphemeral(true).queue();
+
+        int playerId = dsm.syncAccount(toFind);
+        if (playerId == 0) {
+            event.reply("Could not sync account, no player record found.").setEphemeral(true).queue();
             return;
         }
-        else if (playerId == 0) {
-            event.reply("Could not sync account, no player record found.").setEphemeral(true).queue();
+        else if (PlayerUtils.syncExists(toFind)) {
+            event.reply("You have already synced this account. If this is in error, please contact staff.").setEphemeral(true).queue();
             return;
         }
 

--- a/src/main/java/com/everneth/emi/commands/bot/ConfirmSyncCommand.java
+++ b/src/main/java/com/everneth/emi/commands/bot/ConfirmSyncCommand.java
@@ -5,6 +5,7 @@ import co.aikar.idb.DbRow;
 import com.everneth.emi.managers.DiscordSyncManager;
 import com.everneth.emi.EMI;
 
+import com.everneth.emi.utils.PlayerUtils;
 import com.jagrosh.jdautilities.command.SlashCommand;
 import net.dv8tion.jda.api.entities.ChannelType;
 import net.dv8tion.jda.api.entities.Member;
@@ -22,112 +23,42 @@ import java.util.concurrent.CompletableFuture;
 
 public class ConfirmSyncCommand extends SlashCommand {
     private CompletableFuture<DbRow> playerObjectFuture;
-    private CompletableFuture<Integer> futurePlayerId;
+
     public ConfirmSyncCommand()
     {
         this.name = "confirmsync";
         this.help = "Confirm an account synchronization from a minecraft account";
     }
+
     @Override
     protected void execute(SlashCommandEvent event)
     {
         DiscordSyncManager dsm = DiscordSyncManager.getDSM();
         User toFind = dsm.findSyncRequest(event.getUser());
+
+        int playerId = dsm.syncAccount(toFind);
+        if (toFind == null) {
+            event.reply("No sync request exists for your account or it has already been synced.").setEphemeral(true).queue();
+            return;
+        }
+        else if (PlayerUtils.syncExists(toFind)) {
+            event.reply("You have already synced this account. If this is in error, please contact staff.").setEphemeral(true).queue();
+            return;
+        }
+        else if (playerId == 0) {
+            event.reply("Could not sync account, no player record found.").setEphemeral(true).queue();
+            return;
+        }
+
         long guildId = EMI.getPlugin().getConfig().getLong("guild-id");
         long syncRoleId = EMI.getPlugin().getConfig().getLong("synced-role-id");
-        long pendingRoleId = EMI.getPlugin().getConfig().getLong("pending-role-id");
-        long memberRoleId = EMI.getPlugin().getConfig().getLong("member-role-id");
 
-        if(event.getChannelType() == ChannelType.PRIVATE)
-        {
-            if(toFind == null)
-            {
-                event.reply("No sync request exists for your account or it hs already been synced.").queue();
-            }
-            else {
-                if (syncExists(toFind)) {
-                    event.reply("You have already synced this account. If this is in error, please contact staff.").queue();
-                }
-                else {
-                    int playerId = syncAccount(toFind);
-                    if (playerId == 0) {
-                        event.reply("Could not sync account, no player record found.").queue();
-                    } else {
-                        dsm.removeSyncRequest(this.getPlayerRow(playerId).getString("player_uuid"));
-                        EMI.getJda().getGuildById(guildId).addRoleToMember(
-                                EMI.getJda().getGuildById(guildId).getMemberById(event.getUser().getIdLong()),
-                                EMI.getJda().getGuildById(guildId).getRoleById(syncRoleId)
-                        ).queue();
-                        Role memberRole = EMI.getJda().getGuildById(guildId).getRoleById(memberRoleId);
-                        if (EMI.getPlugin().getConfig().getBoolean("use-pending-role")) {
-                            Role pendingRole = EMI.getJda().getGuildById(guildId).getRoleById(pendingRoleId);
-                            Member member = event.getMember();
-                            if (member.getRoles().contains(pendingRole)) {
-                                member.getRoles().remove(pendingRole);
-                                member.getRoles().add(memberRole);
-                                event.reply("Your account has been synced and your roles updated!").queue();
-                            } else {
-                                event.reply("Your account has been synced!").queue();
-                            }
-                        } else {
-                            event.reply("Your account has been synced!").queue();
-                        }
-                    }
-                }
-            }
-        }
-    }
-    private boolean syncExists(User user)
-    {
-        DbRow playerRow;
-        Long discordId = 0L;
-        DiscordSyncManager dsm = DiscordSyncManager.getDSM();
-        playerObjectFuture = DB.getFirstRowAsync("SELECT discord_id FROM players\n" +
-                "WHERE player_uuid = ?", dsm.findSyncRequestUUID(user).toString());
-        // get the results from the future
-        try {
-            playerRow = playerObjectFuture.get();
-            discordId = playerRow.getLong("discord_id");
-        }
-        catch (Exception e)
-        {
-            System.out.print(e.getMessage());
-        }
-        if(discordId == null || discordId == 0)
-            return false;
-        else
-        {
-            return true;
-        }
-    }
-    private int syncAccount(User user)
-    {
-        DiscordSyncManager dsm = DiscordSyncManager.getDSM();
-        int playerId = 0;
-        futurePlayerId = DB.executeUpdateAsync("UPDATE players SET discord_id = ? " +
-                "WHERE player_uuid = ?", user.getIdLong(), dsm.findSyncRequestUUID(user).toString());
-        // get the results from the future
-        try {
-             playerId = futurePlayerId.get();
-        }
-        catch (Exception e)
-        {
-            System.out.print(e.getMessage());
-        }
-        return playerId;
-    }
-    private DbRow getPlayerRow(int id)
-    {
-        CompletableFuture<DbRow> futurePlayer;
-        DbRow player = new DbRow();
-        futurePlayer = DB.getFirstRowAsync("SELECT * FROM players WHERE player_id = ?", id);
-        try {
-            player = futurePlayer.get();
-        }
-        catch (Exception e)
-        {
-            EMI.getPlugin().getLogger().info(e.getMessage());
-        }
-        return player;
+        dsm.removeSyncRequest(PlayerUtils.getPlayerRow(playerId).getString("player_uuid"));
+        EMI.getJda().getGuildById(guildId).addRoleToMember(
+                EMI.getJda().getGuildById(guildId).getMemberById(event.getUser().getIdLong()),
+                EMI.getJda().getGuildById(guildId).getRoleById(syncRoleId)
+        ).queue();
+
+        event.reply("Your account has been synced and your roles updated!").queue();
     }
 }

--- a/src/main/java/com/everneth/emi/commands/bot/ConfirmSyncCommand.java
+++ b/src/main/java/com/everneth/emi/commands/bot/ConfirmSyncCommand.java
@@ -13,6 +13,7 @@ import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -56,7 +57,8 @@ public class ConfirmSyncCommand extends SlashCommand {
         long guildId = EMI.getPlugin().getConfig().getLong("guild-id");
         long syncRoleId = EMI.getPlugin().getConfig().getLong("synced-role-id");
 
-        dsm.removeSyncRequest(PlayerUtils.getPlayerRow(playerId).getString("player_uuid"));
+        UUID key = dsm.findSyncRequestUUID(event.getUser());
+        dsm.removeSyncRequest(key.toString());
         EMI.getJda().getGuildById(guildId).addRoleToMember(
                 EMI.getJda().getGuildById(guildId).getMemberById(event.getUser().getIdLong()),
                 EMI.getJda().getGuildById(guildId).getRoleById(syncRoleId)

--- a/src/main/java/com/everneth/emi/commands/bot/ConfirmSyncCommand.java
+++ b/src/main/java/com/everneth/emi/commands/bot/ConfirmSyncCommand.java
@@ -27,8 +27,6 @@ public class ConfirmSyncCommand extends SlashCommand {
     {
         this.name = "confirmsync";
         this.help = "Confirm an account synchronization from a minecraft account";
-
-        this.guildOnly = false;
     }
     @Override
     protected void execute(SlashCommandEvent event)

--- a/src/main/java/com/everneth/emi/commands/bot/DenySyncCommand.java
+++ b/src/main/java/com/everneth/emi/commands/bot/DenySyncCommand.java
@@ -4,6 +4,7 @@ import com.everneth.emi.managers.DiscordSyncManager;
 import com.everneth.emi.EMI;
 import com.jagrosh.jdautilities.command.SlashCommand;
 import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 
 import java.util.UUID;
@@ -21,6 +22,8 @@ public class DenySyncCommand extends SlashCommand {
     {
         this.name = "denysync";
         this.help = "Deny a synchronization request to your discord account.";
+
+        this.guildOnly = false;
     }
     @Override
     public void execute(SlashCommandEvent event)
@@ -29,11 +32,11 @@ public class DenySyncCommand extends SlashCommand {
 
         if(key == null && !hasSyncRole(event))
         {
-            event.reply("No request found. It either expired or the server was restarted.").queue();
+            event.reply("No request found. It either expired or the server was restarted.").setEphemeral(true).queue();
         }
         else if (key == null && hasSyncRole(event))
         {
-            event.reply("Your account is already synced and running this command did nothing.").queue();
+            event.reply("Your account is already synced and running this command did nothing.").setEphemeral(true).queue();
         }
         else if (key != null)
         {
@@ -45,8 +48,8 @@ public class DenySyncCommand extends SlashCommand {
     private boolean hasSyncRole(SlashCommandEvent event)
     {
         long guildId = EMI.getPlugin().getConfig().getLong("guild-id");
-        long syncRoleId = EMI.getPlugin().getConfig().getLong("sync-role-id");
+        long syncRoleId = EMI.getPlugin().getConfig().getLong("synced-role-id");
         Role syncRole = EMI.getJda().getGuildById(guildId).getRoleById(syncRoleId);
-        return event.getMember().getRoles().contains(syncRole);
+        return EMI.getJda().getGuildById(guildId).getMemberById(event.getUser().getIdLong()).getRoles().contains(syncRole);
     }
 }

--- a/src/main/java/com/everneth/emi/commands/bot/DenySyncCommand.java
+++ b/src/main/java/com/everneth/emi/commands/bot/DenySyncCommand.java
@@ -2,9 +2,9 @@ package com.everneth.emi.commands.bot;
 
 import com.everneth.emi.managers.DiscordSyncManager;
 import com.everneth.emi.EMI;
-import com.jagrosh.jdautilities.command.Command;
-import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.command.SlashCommand;
 import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 
 import java.util.UUID;
 
@@ -14,38 +14,41 @@ import java.util.UUID;
  *     Purpose: The JDA bot !!denysync command that removes the active sync request from the service
  */
 
-public class DenySyncCommand extends Command {
+public class DenySyncCommand extends SlashCommand {
     private DiscordSyncManager dsm = DiscordSyncManager.getDSM();
 
     public DenySyncCommand()
     {
         this.name = "denysync";
+        this.help = "Deny a synchronization request to your discord account.";
+
         this.guildOnly = false;
     }
     @Override
-    public void execute(CommandEvent event)
+    public void execute(SlashCommandEvent event)
     {
-        UUID key = dsm.findSyncRequestUUID(event.getAuthor());
+        UUID key = dsm.findSyncRequestUUID(event.getUser());
 
         if(key == null && !hasSyncRole(event))
         {
-            event.replyInDm("No request found. It either expired or the server was restarted.");
+            event.reply("No request found. It either expired or the server was restarted.").queue();
         }
         else if (key == null && hasSyncRole(event))
         {
-            event.replyInDm("Your account is already synced and running this command did nothing.");
+            event.reply("Your account is already synced and running this command did nothing.").queue();
         }
         else if (key != null)
         {
             dsm.removeSyncRequest(key.toString());
-            event.replyInDm("Sync request denied successfully.");
+            event.reply("Sync request denied successfully.").queue();
         }
     }
-    private boolean hasSyncRole(CommandEvent event)
+
+    private boolean hasSyncRole(SlashCommandEvent event)
     {
         long guildId = EMI.getPlugin().getConfig().getLong("guild-id");
         long syncRoleId = EMI.getPlugin().getConfig().getLong("sync-role-id");
         Role syncRole = EMI.getJda().getGuildById(guildId).getRoleById(syncRoleId);
-        return EMI.getJda().getGuildById(guildId).getMember(event.getSelfUser()).getRoles().contains(syncRole);
+        return event.getMember().getRoles().contains(syncRole);
     }
 }

--- a/src/main/java/com/everneth/emi/commands/bot/DenySyncCommand.java
+++ b/src/main/java/com/everneth/emi/commands/bot/DenySyncCommand.java
@@ -21,8 +21,6 @@ public class DenySyncCommand extends SlashCommand {
     {
         this.name = "denysync";
         this.help = "Deny a synchronization request to your discord account.";
-
-        this.guildOnly = false;
     }
     @Override
     public void execute(SlashCommandEvent event)

--- a/src/main/java/com/everneth/emi/commands/bot/HelpClearCommand.java
+++ b/src/main/java/com/everneth/emi/commands/bot/HelpClearCommand.java
@@ -28,8 +28,8 @@ public class HelpClearCommand extends SlashCommand {
         this.name = "help-clear";
         this.help = "Clears the help channel, but must be used inside of that channel.";
 
-        // we should integrate some way to read in these on a per-command basis
-        //this.enabledRoles = new String[]{"178104117238038528"};
+        this.defaultEnabled = false;
+        this.enabledRoles = new String[]{EMI.getPlugin().getConfig().getString("staff-role-id")};
     }
     @Override
     protected void execute(SlashCommandEvent event)

--- a/src/main/java/com/everneth/emi/commands/bot/HelpClearCommand.java
+++ b/src/main/java/com/everneth/emi/commands/bot/HelpClearCommand.java
@@ -34,66 +34,48 @@ public class HelpClearCommand extends SlashCommand {
     @Override
     protected void execute(SlashCommandEvent event)
     {
-        // We need to make sure the command sender has the correct authorized roles.
-        // Assume no one has roles
-        boolean hasRequiredRoles = false;
+        // You have permissions, but this is the wrong channel you goon
+        if (event.getChannel().getIdLong() != EMI.getPlugin().getConfig().getLong("help-channel-id")) {
+            event.reply("Sorry dear, you *can* use this command but **not** in this channel. :heart: ").setEphemeral(true).queue();
+            return;
+        }
 
-        // Get the roles from the member
-        List<Role> roleList = event.getMember().getRoles();
+        // Got the role! Lets build a list of messages to clear.
+        List<Message> messageList = event.getTextChannel().getIterableHistory().complete();
+        if (messageList.size() == 1) {
+            // Hold up! Theres only the root message and the command! Delete the command, instruct the user
+            event.getChannel().deleteMessageById(event.getChannel().getLatestMessageIdLong()).queue();
+            event.reply("There is nothing to clear in #help, hun! Careful with this command!").setEphemeral(true).queue();
+            return;
+        }
 
-        // Lets check them
-        for(Role role : roleList)
-        {
-            if(role.getName().equals("Staff"))
-            {
-                // Found a required role, no need to find the other, break from the loop
-                hasRequiredRoles = true;
-                break;
+        // Take our messages and build a string, we'll dump that string into a message file
+        // and embed the file into a message
+        File embedFile = transcribe(messageList);
+        Message message = new MessageBuilder().append("Transcript from #help").build();
+        Long staffChannelId = EMI.getPlugin().getConfig().getLong("staff-channel-id");
+        event.getGuild().getTextChannelById(staffChannelId).sendMessage(message).addFile(embedFile).queue();
+
+        // We've got a history, lets clear out
+        for (Message msg : messageList) {
+            // Is message the root?
+            if (msg.getIdLong() == EMI.getPlugin().getConfig().getLong("root-report-msg"))
+                continue;
+
+            try {
+                // No, delete
+                event.getChannel().deleteMessageById(msg.getIdLong()).queue();
+
+                // We sleep the thread for one second to avoid hitting the rate limit
+                Thread.sleep(1000);
+            } catch (Exception e) {
+                EMI.getPlugin().getLogger().severe(e.getMessage());
             }
         }
-        // We've looped through. Do we have the role?
-        if(hasRequiredRoles)
-        {
-            if(event.getChannel().getIdLong() == EMI.getPlugin().getConfig().getLong("report-channel"))
-            {
-                // Got the role! Lets build a list of messages to clear.
-                List<Message> messageList = event.getTextChannel().getIterableHistory().complete();
-                if(messageList.size() == 2) {
-                    // Hold up! Theres only the root message and the command! Delete the command, instruct the user
-                    event.getChannel().deleteMessageById(event.getChannel().getLatestMessageIdLong()).queue();
-                    event.reply("There is nothing to clear in #help, hun! Careful with this command!").setEphemeral(true).queue();
-                }
-                else {
-                    // Take our messages and build a string, we'll dump that string into a message file
-                    // and embed the file into a message
-                    File embedFile = transcribe(messageList);
-                    Message message = new MessageBuilder().append("Transcript from #help").build();
-                    event.getGuild().getTextChannelById(178247194862682112L).sendMessage(message).addFile(embedFile).queue();
 
-                    // We've got a history, lets clear out
-                    for (Message msg : messageList) {
-                        // Is message the root?
-                        if (msg.getIdLong() != EMI.getPlugin().getConfig().getLong("root-report-msg")) {
-                            // No, delete
-                            event.getChannel().deleteMessageById(msg.getIdLong()).queue();
-                        }
-                    }
-                    event.reply("Channel cleared, dear. <3").setEphemeral(true).queue();
-                }
-            }
-            else
-            {
-                // You have permissions, but this is the wrong channel you goon
-                event.reply("Sorry dear, you *can* use this command but **not** in this channel. :heart: ").setEphemeral(true).queue();
-            }
-        }
-        else
-        {
-            // You can;t even use this at all, we're not checking any further
-            // TODO: Mute member if attempts are made to use command to spam replies
-            event.reply("Sorry dear, you do not have the required role to use this command. :heart: ").setEphemeral(true).queue();
-        }
+        event.reply("Channel cleared, dear. <3").setEphemeral(true).queue();
     }
+
     private File transcribe(List<Message> messageList)
     {
         StringBuilder sb = new StringBuilder();

--- a/src/main/java/com/everneth/emi/commands/bot/HelpClearCommand.java
+++ b/src/main/java/com/everneth/emi/commands/bot/HelpClearCommand.java
@@ -2,12 +2,12 @@ package com.everneth.emi.commands.bot;
 
 import com.everneth.emi.EMI;
 import com.everneth.emi.utils.FileUtils;
-import com.jagrosh.jdautilities.command.Command;
-import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.command.SlashCommand;
 import net.dv8tion.jda.api.MessageBuilder;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageHistory;
 import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 
 import java.io.File;
 import java.io.IOException;
@@ -21,14 +21,18 @@ import java.util.List;
  *     Purpose: The JDA bot !!help-clear command that removes all but the specified message by id
  */
 
-public class HelpClearCommand extends Command {
+public class HelpClearCommand extends SlashCommand {
 
     public HelpClearCommand()
     {
         this.name = "help-clear";
+        this.help = "Clears the help channel, but must be used inside of that channel.";
+
+        // we should integrate some way to read in these on a per-command basis
+        //this.enabledRoles = new String[]{"178104117238038528"};
     }
     @Override
-    protected void execute(CommandEvent event)
+    protected void execute(SlashCommandEvent event)
     {
         // We need to make sure the command sender has the correct authorized roles.
         // Assume no one has roles
@@ -57,7 +61,7 @@ public class HelpClearCommand extends Command {
                 if(messageList.size() == 2) {
                     // Hold up! Theres only the root message and the command! Delete the command, instruct the user
                     event.getChannel().deleteMessageById(event.getChannel().getLatestMessageIdLong()).queue();
-                    event.replyInDm("There is nothing to clear in #help, hun! Careful with this command!");
+                    event.reply("There is nothing to clear in #help, hun! Careful with this command!").setEphemeral(true).queue();
                 }
                 else {
                     // Take our messages and build a string, we'll dump that string into a message file
@@ -74,20 +78,20 @@ public class HelpClearCommand extends Command {
                             event.getChannel().deleteMessageById(msg.getIdLong()).queue();
                         }
                     }
-                    event.replyInDm("Channel cleared, dear. <3 ");
+                    event.reply("Channel cleared, dear. <3").setEphemeral(true).queue();
                 }
             }
             else
             {
                 // You have permissions, but this is the wrong channel you goon
-                event.reply("Sorry dear, you *can* use this command but **not** in this channel. :heart: ");
+                event.reply("Sorry dear, you *can* use this command but **not** in this channel. :heart: ").setEphemeral(true).queue();
             }
         }
         else
         {
             // You can;t even use this at all, we're not checking any further
             // TODO: Mute member if attempts are made to use command to spam replies
-            event.reply("Sorry dear, you do not have the required role to use this command. :heart: ");
+            event.reply("Sorry dear, you do not have the required role to use this command. :heart: ").setEphemeral(true).queue();
         }
     }
     private File transcribe(List<Message> messageList)

--- a/src/main/java/com/everneth/emi/commands/bot/HelpClearCommand.java
+++ b/src/main/java/com/everneth/emi/commands/bot/HelpClearCommand.java
@@ -44,7 +44,6 @@ public class HelpClearCommand extends SlashCommand {
         List<Message> messageList = event.getTextChannel().getIterableHistory().complete();
         if (messageList.size() == 1) {
             // Hold up! Theres only the root message and the command! Delete the command, instruct the user
-            event.getChannel().deleteMessageById(event.getChannel().getLatestMessageIdLong()).queue();
             event.reply("There is nothing to clear in #help, hun! Careful with this command!").setEphemeral(true).queue();
             return;
         }

--- a/src/main/java/com/everneth/emi/commands/bot/RequestWhitelistCommand.java
+++ b/src/main/java/com/everneth/emi/commands/bot/RequestWhitelistCommand.java
@@ -2,6 +2,7 @@ package com.everneth.emi.commands.bot;
 
 
 import co.aikar.idb.DbRow;
+import com.everneth.emi.EMI;
 import com.everneth.emi.services.WhitelistService;
 import com.everneth.emi.utils.PlayerUtils;
 import com.jagrosh.jdautilities.command.SlashCommand;
@@ -20,6 +21,9 @@ public class RequestWhitelistCommand extends SlashCommand {
 
         this.options = new ArrayList<>();
         this.options.add(new OptionData(OptionType.STRING, "name", "Your minecraft username").setRequired(true));
+
+        this.defaultEnabled = false;
+        this.enabledRoles = new String[]{EMI.getPlugin().getConfig().getString("member-role-id")};
     }
 
     @Override

--- a/src/main/java/com/everneth/emi/commands/bot/RequestWhitelistCommand.java
+++ b/src/main/java/com/everneth/emi/commands/bot/RequestWhitelistCommand.java
@@ -30,7 +30,7 @@ public class RequestWhitelistCommand extends SlashCommand {
     protected void execute(SlashCommandEvent event) {
         DbRow playerRow = PlayerUtils.getPlayerRow(event.getMember().getIdLong());
         if (playerRow != null) {
-            event.reply("You are already synced, you do not need to apply for temporary whitelisting.").queue();
+            event.reply("You are already synced, you do not need to apply for temporary whitelisting.").setEphemeral(true).queue();
             return;
         }
         String username = event.getOption("name").getAsString();

--- a/src/main/java/com/everneth/emi/commands/bot/RequestWhitelistCommand.java
+++ b/src/main/java/com/everneth/emi/commands/bot/RequestWhitelistCommand.java
@@ -28,25 +28,6 @@ public class RequestWhitelistCommand extends SlashCommand {
 
     @Override
     protected void execute(SlashCommandEvent event) {
-        // We need to make sure the command sender has the correct authorized roles.
-        // Assume no one has roles
-        boolean hasRequiredRoles = false;
-        // Get the roles from the member
-        List<Role> roleList = event.getMember().getRoles();
-        // Lets check them
-        for(Role role : roleList)
-        {
-            if(role.getName().equals("Citizen"))
-            {
-                // Found a required role, no need to find the other, break from the loop
-                hasRequiredRoles = true;
-                break;
-            }
-        }
-        if (!hasRequiredRoles) {
-            event.reply("You do not have the Citizen role!").setEphemeral(true).queue();
-            return;
-        }
         DbRow playerRow = PlayerUtils.getPlayerRow(event.getMember().getIdLong());
         if (playerRow != null) {
             event.reply("You are already synced, you do not need to apply for temporary whitelisting.").queue();

--- a/src/main/java/com/everneth/emi/commands/bot/RequestWhitelistCommand.java
+++ b/src/main/java/com/everneth/emi/commands/bot/RequestWhitelistCommand.java
@@ -4,17 +4,26 @@ package com.everneth.emi.commands.bot;
 import co.aikar.idb.DbRow;
 import com.everneth.emi.services.WhitelistService;
 import com.everneth.emi.utils.PlayerUtils;
-import com.jagrosh.jdautilities.command.Command;
-import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.command.SlashCommand;
 import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 
+import java.util.ArrayList;
 import java.util.List;
 
-public class RequestWhitelistCommand extends Command {
-    public RequestWhitelistCommand() { this.name = "whitelist"; }
+public class RequestWhitelistCommand extends SlashCommand {
+    public RequestWhitelistCommand() {
+        this.name = "whitelist";
+        this.help = "Request temporary whitelisting so you may synchronize your discord and minecraft accounts";
+
+        this.options = new ArrayList<>();
+        this.options.add(new OptionData(OptionType.STRING, "name", "Your minecraft username").setRequired(true));
+    }
 
     @Override
-    protected void execute(CommandEvent event) {
+    protected void execute(SlashCommandEvent event) {
         // We need to make sure the command sender has the correct authorized roles.
         // Assume no one has roles
         boolean hasRequiredRoles = false;
@@ -31,25 +40,25 @@ public class RequestWhitelistCommand extends Command {
             }
         }
         if (!hasRequiredRoles) {
-            event.reply("You do not have the Citizen role!");
+            event.reply("You do not have the Citizen role!").setEphemeral(true).queue();
             return;
         }
         DbRow playerRow = PlayerUtils.getPlayerRow(event.getMember().getIdLong());
         if (playerRow != null) {
-            event.reply("You are already synced, you do not need to apply for temporary whitelisting.");
+            event.reply("You are already synced, you do not need to apply for temporary whitelisting.").queue();
             return;
         }
-        String username = event.getArgs().split(" ")[0];
+        String username = event.getOption("name").getAsString();
         if (username == null || username.isEmpty()) {
-            event.reply("You did not provide a name for me to whitelist");
+            event.reply("You did not provide a name for me to whitelist").setEphemeral(true).queue();
             return;
         }
         if (PlayerUtils.getPlayerRow(username) != null || WhitelistService.getService().isWhitelisted(username)) {
-            event.reply("That user is already on the whitelist. If this is an error please contact Staff.");
+            event.reply("That user is already on the whitelist. If this is an error please contact Staff.").setEphemeral(true).queue();
             return;
         }
 
         WhitelistService.getService().addToWhitelistTemporarily(username);
-        event.reply("Added you to the whitelist for 5 minutes. Please login to `play.everneth.com` and use `/discord sync <Name#0000>`");
+        event.reply("Added you to the whitelist for 5 minutes. Please login to `play.everneth.com` and use `/discord sync <Name#0000>`").queue();
     }
 }

--- a/src/main/java/com/everneth/emi/commands/bot/StartVoteCommand.java
+++ b/src/main/java/com/everneth/emi/commands/bot/StartVoteCommand.java
@@ -1,45 +1,54 @@
 package com.everneth.emi.commands.bot;
 
 import com.everneth.emi.EMI;
-import com.jagrosh.jdautilities.command.Command;
-import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.command.SlashCommand;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction;
 
-public class StartVoteCommand extends Command {
+import javax.swing.text.html.Option;
+import java.io.CharArrayReader;
+import java.sql.Array;
+import java.util.ArrayList;
+
+public class StartVoteCommand extends SlashCommand {
 
     public StartVoteCommand()
     {
-        this.name ="startvote";
+        this.name = "startvote";
+        this.help = "Forcefully start a whitelist vote for a user";
+
+        this.options = new ArrayList<>();
+        this.options.add(new OptionData(OptionType.USER, "user", "The user you would like to start a vote for."));
         this.guildOnly = false;
     }
     @Override
-    protected void execute(CommandEvent event)
+    protected void execute(SlashCommandEvent event)
     {
         Role ministryMember = event.getGuild().getRoleById(455522908521889814L);
         Role staffRole = event.getGuild().getRoleById(EMI.getPlugin().getConfig().getLong("staff-role-id"));
         if(event.getMember().getRoles().contains(ministryMember) || event.getMember().getRoles().contains(staffRole))
         {
-            Member member = event.getGuild().getMemberByTag(event.getArgs());
+            Member member = event.getGuild().getMemberByTag(event.getOption("name").getAsString());
             if(event.getGuild().getMembers().contains(member))
             {
-                event.reply(event.getAuthor().getName() + " has requested a vote for " + event.getArgs() +
-                        ". 3 positive reactions are required for the vote to be sent to staff.", (message -> {
-                            message.addReaction("white_check_mark").queue();
-                            message.addReaction("no_entry").queue();
-                }));
+                event.reply(event.getUser().getName() + " has requested a vote for " + event.getOption("name").getAsString() +
+                        ". 3 positive reactions are required for the vote to be sent to staff.").queue();
 
             }
             else
             {
-                event.reply("Could not find this user. Did you @mention them?");
+                event.reply("Could not find this user. Did you @mention them?").setEphemeral(true).queue();
             }
 
         }
         else
         {
-            event.reply("You cannot use this command.");
+            event.reply("You cannot use this command.").setEphemeral(true).queue();
         }
     }
 }

--- a/src/main/java/com/everneth/emi/commands/bot/UnsyncCommand.java
+++ b/src/main/java/com/everneth/emi/commands/bot/UnsyncCommand.java
@@ -4,21 +4,27 @@ import co.aikar.idb.DB;
 import co.aikar.idb.DbRow;
 import com.everneth.emi.EMI;
 import com.everneth.emi.utils.PlayerUtils;
-import com.jagrosh.jdautilities.command.Command;
-import com.jagrosh.jdautilities.command.CommandEvent;
+import com.jagrosh.jdautilities.command.SlashCommand;
 import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.scheduler.BukkitScheduler;
 
-public class UnsyncCommand extends Command {
+public class UnsyncCommand extends SlashCommand {
 
-    public UnsyncCommand() { this.name = "unsync"; }
+    public UnsyncCommand() {
+        this.name = "unsync";
+        this.help = "If you lost access to your minecraft account, use this to remove the sync to it.";
+    }
 
     @Override
-    public void execute(CommandEvent event) {
+    public void execute(SlashCommandEvent event) {
         // the player does not have a synced account, we can ignore them
-        if (!PlayerUtils.isMember(event.getMember().getIdLong()))
+        Long memberId = event.getMember().getIdLong();
+        if (!PlayerUtils.isMember(memberId)) {
+            event.reply("Your account is not synchronized.").setEphemeral(true).queue();
             return;
+        }
 
         DbRow playerRow = PlayerUtils.getPlayerRow(event.getMember().getIdLong());
         String playerUsername = playerRow.getString("player_name");
@@ -40,6 +46,6 @@ public class UnsyncCommand extends Command {
                 event.getMember().getIdLong());
 
         event.reply("Your discord has been unsynced and your accounts have been removed from the whitelist. " +
-                "Please use `!whitelist <username>` to temporarily add another account to the whitelist so you may re-sync.");
+                "Please use `/whitelist <username>` to temporarily add another account to the whitelist so you may re-sync.");
     }
 }

--- a/src/main/java/com/everneth/emi/commands/bot/UnsyncCommand.java
+++ b/src/main/java/com/everneth/emi/commands/bot/UnsyncCommand.java
@@ -15,6 +15,9 @@ public class UnsyncCommand extends SlashCommand {
     public UnsyncCommand() {
         this.name = "unsync";
         this.help = "If you lost access to your minecraft account, use this to remove the sync to it.";
+
+        this.defaultEnabled = false;
+        this.enabledRoles = new String[]{EMI.getPlugin().getConfig().getString("member-role-id")};
     }
 
     @Override

--- a/src/main/java/com/everneth/emi/commands/bot/UnsyncCommand.java
+++ b/src/main/java/com/everneth/emi/commands/bot/UnsyncCommand.java
@@ -17,7 +17,7 @@ public class UnsyncCommand extends SlashCommand {
         this.help = "If you lost access to your minecraft account, use this to remove the sync to it.";
 
         this.defaultEnabled = false;
-        this.enabledRoles = new String[]{EMI.getPlugin().getConfig().getString("member-role-id")};
+        this.enabledRoles = new String[]{EMI.getPlugin().getConfig().getString("synced-role-id")};
     }
 
     @Override

--- a/src/main/java/com/everneth/emi/commands/bot/par/WhitelistAppCommand.java
+++ b/src/main/java/com/everneth/emi/commands/bot/par/WhitelistAppCommand.java
@@ -21,6 +21,7 @@ public class WhitelistAppCommand extends SlashCommand {
         this.name = "application";
         this.help = "All commands pertaining to user applications";
 
+        this.defaultEnabled = false;
         this.children = new SlashCommand[]{new GetAllApps(), new GetApp()};
     }
 

--- a/src/main/java/com/everneth/emi/commands/bot/par/WhitelistAppCommand.java
+++ b/src/main/java/com/everneth/emi/commands/bot/par/WhitelistAppCommand.java
@@ -70,6 +70,7 @@ public class WhitelistAppCommand extends SlashCommand {
             this.name = "all";
             this.help = "Gets the applications for all current applicants.";
 
+            this.defaultEnabled = false;
             this.enabledRoles = new String[]{EMI.getPlugin().getConfig().getString("staff-role-id")};
         }
         @Override

--- a/src/main/java/com/everneth/emi/commands/bot/par/WhitelistAppCommand.java
+++ b/src/main/java/com/everneth/emi/commands/bot/par/WhitelistAppCommand.java
@@ -22,6 +22,8 @@ public class WhitelistAppCommand extends SlashCommand {
         this.help = "All commands pertaining to user applications";
 
         this.defaultEnabled = false;
+        this.enabledRoles = new String[]{EMI.getPlugin().getConfig().getString("staff-role-id")};
+        
         this.children = new SlashCommand[]{new GetAllApps(), new GetApp()};
     }
 

--- a/src/main/java/com/everneth/emi/commands/bot/par/WhitelistAppCommand.java
+++ b/src/main/java/com/everneth/emi/commands/bot/par/WhitelistAppCommand.java
@@ -1,5 +1,6 @@
 package com.everneth.emi.commands.bot.par;
 
+import com.everneth.emi.EMI;
 import com.everneth.emi.models.WhitelistApp;
 import com.everneth.emi.services.WhitelistAppService;
 import com.jagrosh.jdautilities.command.SlashCommand;
@@ -68,7 +69,8 @@ public class WhitelistAppCommand extends SlashCommand {
         {
             this.name = "all";
             this.help = "Gets the applications for all current applicants.";
-            this.guildOnly = true;
+
+            this.enabledRoles = new String[]{EMI.getPlugin().getConfig().getString("staff-role-id")};
         }
         @Override
         protected void execute(SlashCommandEvent event)
@@ -91,10 +93,12 @@ public class WhitelistAppCommand extends SlashCommand {
         {
             this.name = "get";
             this.help = "Get an application for an applicant";
-            this.guildOnly = true;
 
             this.options = new ArrayList<>();
             this.options.add(new OptionData(OptionType.STRING, "id", "The user's unique identifier").setRequired(true));
+
+            this.defaultEnabled = false;
+            this.enabledRoles = new String[]{EMI.getPlugin().getConfig().getString("staff-role-id")};
         }
         @Override
         protected void execute(SlashCommandEvent event)

--- a/src/main/java/com/everneth/emi/commands/bot/par/WhitelistAppCommand.java
+++ b/src/main/java/com/everneth/emi/commands/bot/par/WhitelistAppCommand.java
@@ -20,7 +20,7 @@ public class WhitelistAppCommand extends SlashCommand {
     {
         this.name = "application";
         this.help = "All commands pertaining to user applications";
-        
+
         this.children = new SlashCommand[]{new GetAllApps(), new GetApp()};
     }
 

--- a/src/main/java/com/everneth/emi/commands/bot/par/WhitelistAppCommand.java
+++ b/src/main/java/com/everneth/emi/commands/bot/par/WhitelistAppCommand.java
@@ -20,9 +20,6 @@ public class WhitelistAppCommand extends SlashCommand {
     {
         this.name = "application";
         this.help = "All commands pertaining to user applications";
-
-        this.defaultEnabled = false;
-        this.enabledRoles = new String[]{EMI.getPlugin().getConfig().getString("staff-role-id")};
         
         this.children = new SlashCommand[]{new GetAllApps(), new GetApp()};
     }

--- a/src/main/java/com/everneth/emi/events/bot/GuildLeaveListener.java
+++ b/src/main/java/com/everneth/emi/events/bot/GuildLeaveListener.java
@@ -6,7 +6,6 @@ import com.everneth.emi.EMI;
 import com.everneth.emi.services.VotingService;
 import com.everneth.emi.services.WhitelistAppService;
 import net.dv8tion.jda.api.entities.Role;
-import net.dv8tion.jda.api.events.guild.member.GuildMemberLeaveEvent;
 import net.dv8tion.jda.api.events.guild.member.GuildMemberRemoveEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 

--- a/src/main/java/com/everneth/emi/events/bot/MessageReceivedListener.java
+++ b/src/main/java/com/everneth/emi/events/bot/MessageReceivedListener.java
@@ -28,7 +28,6 @@ import org.apache.http.util.EntityUtils;
 
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
-import org.json.JSONObject;
 
 import java.io.IOException;
 import java.sql.SQLException;
@@ -159,7 +158,7 @@ public class MessageReceivedListener extends ListenerAdapter {
                                 eb.addField("What is the secret word?", appInProgress.getSecretWord(), false);
                                 eb.setFooter("THIS IS A PREVIEW APPLICATION AND MUST BE CONFIRMED BEFORE SENDING!");
 
-                                event.getPrivateChannel().sendMessage(eb.build()).queue();
+                                event.getPrivateChannel().sendMessageEmbeds(eb.build()).queue();
                                 event.getPrivateChannel().sendMessage("Is this information correct? Please reply **yes** or **no**.").queue();
                                 break;
                             case 11:

--- a/src/main/java/com/everneth/emi/events/bot/ReactionListener.java
+++ b/src/main/java/com/everneth/emi/events/bot/ReactionListener.java
@@ -9,9 +9,9 @@ import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageReaction;
 import net.dv8tion.jda.api.entities.Role;
-import net.dv8tion.jda.api.events.message.guild.react.GuildMessageReactionAddEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.dv8tion.jda.api.requests.RestAction;
+import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.scheduler.BukkitRunnable;
 
@@ -23,7 +23,7 @@ public class ReactionListener extends ListenerAdapter {
     private final String REJECT_REACTION = "\u26D4";
 
     @Override
-    public void onGuildMessageReactionAdd(GuildMessageReactionAddEvent event) {
+    public void onMessageReactionAdd(MessageReactionAddEvent event) {
         VotingService votingService = VotingService.getService();
         // Ignore reactions to non-voting messages, reactions from bots, and reactions outside the voting channel
         if (!votingService.isVotingMessage(event.getMessageIdLong()) ||

--- a/src/main/java/com/everneth/emi/managers/DiscordSyncManager.java
+++ b/src/main/java/com/everneth/emi/managers/DiscordSyncManager.java
@@ -1,11 +1,13 @@
 package com.everneth.emi.managers;
 
+import co.aikar.idb.DB;
 import net.dv8tion.jda.api.entities.User;
 import org.bukkit.entity.Player;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 /**
  *     Class: DiscordSyncManager
@@ -18,6 +20,7 @@ public final class DiscordSyncManager {
     private static DiscordSyncManager dsm;
     private HashMap<UUID, User> userMap = new HashMap<UUID, User>();;
     private DiscordSyncManager() {}
+    private CompletableFuture<Integer> futurePlayerId;
     public static DiscordSyncManager getDSM()
     {
         if(dsm == null)
@@ -62,6 +65,7 @@ public final class DiscordSyncManager {
         }
         return null;
     }
+
     private UUID getKeyFromValueUUID(Map hm, User user)
     {
         for (Object o : hm.keySet())
@@ -72,5 +76,22 @@ public final class DiscordSyncManager {
             }
         }
         return null;
+    }
+
+    public int syncAccount(User user)
+    {
+        DiscordSyncManager dsm = DiscordSyncManager.getDSM();
+        int playerId = 0;
+        futurePlayerId = DB.executeUpdateAsync("UPDATE players SET discord_id = ? " +
+                "WHERE player_uuid = ?", user.getIdLong(), dsm.findSyncRequestUUID(user).toString());
+        // get the results from the future
+        try {
+            playerId = futurePlayerId.get();
+        }
+        catch (Exception e)
+        {
+            System.out.print(e.getMessage());
+        }
+        return playerId;
     }
 }

--- a/src/main/java/com/everneth/emi/models/Report.java
+++ b/src/main/java/com/everneth/emi/models/Report.java
@@ -108,7 +108,7 @@ public class Report {
                                 reportToAdd.setDiscordUserId(discordMember.getUser().getIdLong());
                                 rm.addReport(player.getUniqueId(), reportToAdd);
                                 rm.addReportRecord(reportToAdd, playerRow.getInt("player_id"));
-                                channel.getGuild().getTextChannelById(channel.getIdLong()).sendMessage(ebs.build()).queue();
+                                channel.getGuild().getTextChannelById(channel.getIdLong()).sendMessageEmbeds(ebs.build()).queue();
                             });
                 }
                 else
@@ -121,7 +121,7 @@ public class Report {
                                 Report reportToAdd = new Report(channel.getIdLong());
                                 rm.addReport(player.getUniqueId(), reportToAdd);
                                 rm.addReportRecord(reportToAdd, playerRow.getInt("player_id"));
-                                channel.getGuild().getTextChannelById(channel.getIdLong()).sendMessage(ebs.build()).queue();
+                                channel.getGuild().getTextChannelById(channel.getIdLong()).sendMessageEmbeds(ebs.build()).queue();
                             });
                 }
                 break;
@@ -155,7 +155,7 @@ public class Report {
                                 reportToAdd.setDiscordUserId(discordMember.getUser().getIdLong());
                                 rm.addReport(player.getUniqueId(), reportToAdd);
                                 rm.addReportRecord(reportToAdd, playerRow.getInt("player_id"));
-                                channel.getGuild().getTextChannelById(channel.getIdLong()).sendMessage(ebm.build()).queue();
+                                channel.getGuild().getTextChannelById(channel.getIdLong()).sendMessageEmbeds(ebm.build()).queue();
                             });
                 }
                 else
@@ -169,7 +169,7 @@ public class Report {
                                 Report reportToAdd = new Report(channel.getIdLong());
                                 rm.addReport(player.getUniqueId(), reportToAdd);
                                 rm.addReportRecord(reportToAdd, playerRow.getInt("player_id"));
-                                channel.getGuild().getTextChannelById(channel.getIdLong()).sendMessage(ebm.build()).queue();
+                                channel.getGuild().getTextChannelById(channel.getIdLong()).sendMessageEmbeds(ebm.build()).queue();
                             });
                 }
                 break;

--- a/src/main/java/com/everneth/emi/services/WhitelistAppService.java
+++ b/src/main/java/com/everneth/emi/services/WhitelistAppService.java
@@ -16,7 +16,6 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
 import org.bukkit.entity.Player;
-import org.json.JSONObject;
 
 import java.io.IOException;
 import java.sql.SQLException;
@@ -67,12 +66,14 @@ public class WhitelistAppService {
 
     public void messageStaffWithEmbed(EmbedBuilder eb2)
     {
-        EMI.getJda().getGuildById(EMI.getPlugin().getConfig().getLong("guild-id")).getTextChannelById(EMI.getPlugin().getConfig().getLong("voting-channel-id")).sendMessage(eb2.build()).queue();
+        EMI.getJda().getGuildById(EMI.getPlugin().getConfig().getLong("guild-id")).getTextChannelById(EMI.getPlugin().getConfig().getLong("voting-channel-id"))
+                .sendMessageEmbeds(eb2.build()).queue();
     }
 
     public void messageStaff(String msg)
     {
-        EMI.getJda().getGuildById(EMI.getPlugin().getConfig().getLong("guild-id")).getTextChannelById(EMI.getPlugin().getConfig().getLong("voting-channel-id")).sendMessage(msg).queue();
+        EMI.getJda().getGuildById(EMI.getPlugin().getConfig().getLong("guild-id")).getTextChannelById(EMI.getPlugin().getConfig().getLong("voting-channel-id"))
+                .sendMessage(msg).queue();
     }
 
     public WhitelistApp findByDiscordId(long id)

--- a/src/main/java/com/everneth/emi/services/WhitelistAppService.java
+++ b/src/main/java/com/everneth/emi/services/WhitelistAppService.java
@@ -143,7 +143,7 @@ public class WhitelistAppService {
                 id);
         try {
             DB.executeInsert("INSERT INTO players (player_name, player_uuid, discord_id) " +
-                            "VALUES (?, ?, ?, ?)",
+                            "VALUES (?, ?, ?)",
                     playerToAdd.getString("mc_ign"),
                     playerToAdd.getString("mc_uuid"),
                     id);

--- a/src/main/java/com/everneth/emi/services/WhitelistService.java
+++ b/src/main/java/com/everneth/emi/services/WhitelistService.java
@@ -15,7 +15,7 @@ import java.util.concurrent.TimeUnit;
 
 public class WhitelistService {
     private static WhitelistService service;
-    ArrayList<String> whitelistedPlayers = new ArrayList<>();
+    private ArrayList<String> whitelistedPlayers = new ArrayList<>();
 
     public static WhitelistService getService() {
         if (service == null) {
@@ -43,6 +43,17 @@ public class WhitelistService {
                 }
             }
         }, 20L * 60 * 5);
+    }
+
+    public void removeAllFromWhitelist() {
+        BukkitScheduler scheduler = EMI.getPlugin().getServer().getScheduler();
+        for (String username : whitelistedPlayers) {
+            scheduler.callSyncMethod(EMI.getPlugin(), () ->
+                    Bukkit.dispatchCommand(Bukkit.getConsoleSender(), "whitelist remove " + username));
+            DB.executeUpdateAsync("DELETE FROM players WHERE player_name = ?", username);
+        }
+        
+        whitelistedPlayers = new ArrayList<>();
     }
 
     public boolean isWhitelisted(String name) {

--- a/src/main/java/com/everneth/emi/services/WhitelistService.java
+++ b/src/main/java/com/everneth/emi/services/WhitelistService.java
@@ -52,7 +52,7 @@ public class WhitelistService {
                     Bukkit.dispatchCommand(Bukkit.getConsoleSender(), "whitelist remove " + username));
             DB.executeUpdateAsync("DELETE FROM players WHERE player_name = ?", username);
         }
-        
+
         whitelistedPlayers = new ArrayList<>();
     }
 

--- a/src/main/java/com/everneth/emi/utils/PlayerUtils.java
+++ b/src/main/java/com/everneth/emi/utils/PlayerUtils.java
@@ -166,7 +166,11 @@ public class PlayerUtils {
 
     public static boolean syncExists(User user) {
         DbRow playerRow = getPlayerRow(user.getIdLong());
-        return playerRow != null;
+        Long discordId = 0L;
+        if (playerRow != null)
+            discordId = playerRow.getLong("discord_id");
+
+        return discordId != null && discordId != 0;
     }
 
     public static boolean isMember(long discordId)

--- a/src/main/java/com/everneth/emi/utils/PlayerUtils.java
+++ b/src/main/java/com/everneth/emi/utils/PlayerUtils.java
@@ -5,6 +5,7 @@ import co.aikar.idb.DbRow;
 import com.everneth.emi.EMI;
 import com.everneth.emi.models.CharterPoint;
 import com.everneth.emi.models.EMIPlayer;
+import net.dv8tion.jda.api.entities.User;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -161,6 +162,11 @@ public class PlayerUtils {
             discordId = playerRow.getLong("discord_id");
 
         return discordId != null && discordId != 0;
+    }
+
+    public static boolean syncExists(User user) {
+        DbRow playerRow = getPlayerRow(user.getIdLong());
+        return playerRow != null;
     }
 
     public static boolean isMember(long discordId)

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: EMI
-version: 1.5.2
+version: 1.6.0
 main: com.everneth.emi.EMI
 author: tptmike, sterling, jmwren
 api-version: 1.17


### PR DESCRIPTION
Migrated from text-based commands to new slash command interactions. The JDA-Chewtils library has a slash command implementation very similar to that of JDA-Utils, thus the transition from one to the other was as simple as changing the namespaces and queuing any interaction responses. 

Slash commands require that a response be provided, otherwise the interaction will fail. As such, heavy refactoring had to be done to ensure that all command outcomes responded, whether it be ephemeral or not. The changes made are fairly significant and I took the opportunity to do some other refactoring/bug fixes which need to be available whenever we update the plugin jar.