### PR TITLE
Voting fixes

### DIFF
--- a/src/main/java/com/everneth/emi/events/bot/MessageReceivedListener.java
+++ b/src/main/java/com/everneth/emi/events/bot/MessageReceivedListener.java
@@ -139,7 +139,7 @@ public class MessageReceivedListener extends ListenerAdapter {
                                 break;
                             case 9:
                                 appInProgress.setHoldForNextStep(true);
-                                event.getPrivateChannel().sendMessage("What is the secret word? (**Hint**: <https://everneth.com/rules>").queue();
+                                event.getPrivateChannel().sendMessage("What is the secret word? (**Hint**: <https://everneth.com/rules>)").queue();
                                 break;
                             case 10:
                                 appInProgress.setHoldForNextStep(true);

--- a/src/main/java/com/everneth/emi/services/VotingService.java
+++ b/src/main/java/com/everneth/emi/services/VotingService.java
@@ -17,6 +17,7 @@ import net.dv8tion.jda.api.events.interaction.ButtonClickEvent;
 import net.dv8tion.jda.api.exceptions.ErrorHandler;
 import net.dv8tion.jda.api.interactions.components.Button;
 import net.dv8tion.jda.api.requests.ErrorResponse;
+import net.dv8tion.jda.api.requests.restaction.MessageAction;
 import org.apache.commons.lang.StringUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.scheduler.BukkitRunnable;
@@ -70,18 +71,17 @@ public class VotingService {
             guild.addRoleToMember(applicant, syncedRole).queue();
 
             WhitelistAppService.getService().approveWhitelistAppRecord(applicant.getIdLong(), vote.getMessageId());
-            List<Button> disabledButtons = new ArrayList<>();
-            event.getMessage().getButtons().forEach(button -> disabledButtons.add(button.asDisabled()));
-            event.getMessage().editMessage("The vote is now over. Applicant " + applicant.getAsMention() + " accepted.")
-                    .setActionRow(disabledButtons).queueAfter(2, TimeUnit.SECONDS);
+
             guild.getTextChannelById(EMI.getPlugin().getConfig().getLong("whitelist-channel-id"))
                     .sendMessage(applicant.getAsMention() + " has been whitelisted! Congrats!").queue();
 
             vote.setInactive();
         }
-        else {
-            event.getMessage().editMessage("The vote is now over. Applicant " + applicant.getAsMention() + " denied.").queue();
-        }
+
+        List<Button> disabledButtons = new ArrayList<>();
+        event.getMessage().getButtons().forEach(button -> disabledButtons.add(button.asDisabled()));
+        event.getMessage().editMessage("The vote is now over. Applicant " + applicant.getAsMention() + (approved ? " accepted." : " denied."))
+                .setActionRow(disabledButtons).queueAfter(2, TimeUnit.SECONDS);
 
         guild.removeRoleFromMember(applicant, pendingRole).queue();
         voteMap.remove(id);
@@ -225,8 +225,8 @@ public class VotingService {
 
         WhitelistVote vote = voteMap.get(event.getMessage().getIdLong());
         String positiveVoters = vote.getPositiveVoters().stream()
-                        .map(Member::getAsMention)
-                        .collect(Collectors.joining(" "));
+                .map(Member::getAsMention)
+                .collect(Collectors.joining(" "));
         String negativeVoters = vote.getNegativeVoters().stream()
                 .map(Member::getAsMention)
                 .collect(Collectors.joining(" "));

--- a/src/main/java/com/everneth/emi/services/VotingService.java
+++ b/src/main/java/com/everneth/emi/services/VotingService.java
@@ -77,7 +77,26 @@ public class VotingService {
             guild.getTextChannelById(EMI.getPlugin().getConfig().getLong("whitelist-channel-id"))
                     .sendMessage(applicant.getAsMention() + " has been whitelisted! Congrats!").queue();
         }
+        else {
+            applicant.getUser().openPrivateChannel().queue(privateChannel ->
+                    privateChannel.sendMessage("Hey, " + applicant.getEffectiveName() +
+                                    "!\n\nI'm here to notify you that your application has been unfortunately denied. You can ask a staff member " +
+                                    "for specifics but the most common reasons for denial include:\n" +
+                                    "**1)** An incorrect secret word (Did you read the rules?).\n" +
+                                    "**2)** General lack of effort put into the application. You don't have to write an essay, we just want to know " +
+                                    "a little bit about you!\n" +
+                                    "**3)** Behavior deemed inappropriate while interacting with our community members.\n\n" +
+                                    "You are welcome to submit another application a week from now, if you so choose. Feel free to stick around " +
+                                    "and chat until then!")
+                            .queue(null, new ErrorHandler().handle(ErrorResponse.CANNOT_SEND_TO_USER,
+                                    error ->
+                                        EMI.getGuild().getTextChannelById(EMI.getConfigLong("voting-channel-id"))
+                                                .sendMessage("Could not message applicant. Please notify them that they have been denied.")
+                                    )));
+        }
 
+        // I have yet to figure out a better way of going about disabling buttons, the answer is somewhere within ActionRows which
+        // I generally do not understand proper usage of
         List<Button> disabledButtons = new ArrayList<>();
         event.getMessage().getButtons().forEach(button -> disabledButtons.add(button.asDisabled()));
         event.getMessage().editMessage("The vote is now over. Applicant " + applicant.getAsMention() + (approved ? " accepted." : " denied."))


### PR DESCRIPTION
Resolves #93 

The user should now be messaged when their application is denied, with a message provided to the applications channel in the event that the user cannot be messaged. The null checks for vote buttons should prevent any more exceptions from being thrown, and buttons that failed to disable for null votes should now disable properly.